### PR TITLE
Add generic adaptive layout overflow

### DIFF
--- a/crates/gpui-builder/src/lib.rs
+++ b/crates/gpui-builder/src/lib.rs
@@ -83,8 +83,8 @@ pub use inspector::{
 };
 pub use snapshots::{LayoutSnapshot, LayoutSnapshotMatrix, LayoutViewport, solve_snapshot_matrix};
 pub use solved::{
-    LayoutDebugReport, LayoutDebugWarning, LayoutDebugWarningKind, NodeIndex, SolvedNode,
-    SolvedNodeData, SolvedNodeRef, SolvedTree,
+    CollapsedSlot, LayoutDebugReport, LayoutDebugWarning, LayoutDebugWarningKind, NodeIndex,
+    SolvedNode, SolvedNodeData, SolvedNodeRef, SolvedTree,
 };
 pub use solver::{
     TextMeasureCache, solve, solve_tree, solve_tree_into, solve_tree_into_with_cache,

--- a/crates/gpui-builder/src/solved/solved_tree.rs
+++ b/crates/gpui-builder/src/solved/solved_tree.rs
@@ -12,6 +12,18 @@ use std::sync::OnceLock;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeIndex(pub usize);
 
+/// Stable identity and display label for a collapsed layout slot.
+///
+/// Both strings borrow from the source [`LayoutNode`], so iterating collapsed
+/// slots does not allocate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CollapsedSlot<'a> {
+    /// Stable, non-localized slot identifier.
+    pub id: &'a str,
+    /// Human-readable label for an overflow trigger or surface.
+    pub label: &'a str,
+}
+
 /// A single node stored in the flat solved tree.
 #[derive(Debug, Clone)]
 pub struct SolvedNodeData<'a> {
@@ -241,17 +253,26 @@ impl<'a> SolvedTree<'a> {
         self.cached_as_map_index.get().map_or(0, |m| m.len())
     }
 
-    /// Collect all collapsed nodes with their labels.
-    pub fn collapsed_tabs(&self) -> Vec<(&str, &str)> {
+    /// Iterate over collapsed slots in stable pre-order declaration order.
+    ///
+    /// This iterator borrows the solved tree and performs no allocation.
+    pub fn collapsed_slots(&self) -> impl Iterator<Item = CollapsedSlot<'a>> + '_ {
         self.nodes
             .iter()
+            .filter(|node| !node.visible)
             .filter_map(|node| {
-                if !node.visible {
-                    node.collapse_label.map(|label| (node.id, label))
-                } else {
-                    None
-                }
+                node.collapse_label
+                    .map(|label| CollapsedSlot { id: node.id, label })
             })
+    }
+
+    /// Collect all collapsed nodes with their labels.
+    ///
+    /// Compatibility alias for callers using the original tab-shaped API.
+    /// New code should prefer the allocation-free [`Self::collapsed_slots`].
+    pub fn collapsed_tabs(&self) -> Vec<(&str, &str)> {
+        self.collapsed_slots()
+            .map(|slot| (slot.id, slot.label))
             .collect()
     }
 

--- a/crates/gpui-builder/src/solved/tests.rs
+++ b/crates/gpui-builder/src/solved/tests.rs
@@ -1,6 +1,6 @@
 use super::layout_debug_warning::LayoutDebugWarning;
 use super::solved_node::SolvedNode;
-use super::solved_tree::SolvedTree;
+use super::solved_tree::{CollapsedSlot, SolvedTree};
 use super::types::LayoutDebugWarningKind;
 use crate::solver::solve_tree;
 use crate::types::{
@@ -469,6 +469,40 @@ fn flat_tree_collapsed_tabs_match_recursive_collapsed_tabs() {
     recursive_tabs.sort_by_key(|(id, _)| *id);
     flat_tabs.sort_by_key(|(id, _)| *id);
     assert_eq!(flat_tabs, recursive_tabs);
+}
+
+#[test]
+fn collapsed_slots_preserve_stable_ids_and_declaration_order() {
+    let children = [
+        LayoutNode::Slot(SlotNode::new("first", Sizing::Fixed(100.0)).collapsible(0.5, "First")),
+        LayoutNode::slot("primary", Sizing::Fixed(200.0)),
+        LayoutNode::Slot(SlotNode::new("last", Sizing::Fixed(100.0)).collapsible(0.5, "Last")),
+    ];
+    let root =
+        ContainerNode::new("root", Axis::Horizontal, Sizing::flex(0.0), &children).into_node();
+    let solved = solve_tree(&root, 200.0, 400.0, &LayoutPreferences::default());
+
+    let collapsed: Vec<_> = solved.collapsed_slots().collect();
+    assert_eq!(
+        collapsed,
+        vec![
+            CollapsedSlot {
+                id: "first",
+                label: "First",
+            },
+            CollapsedSlot {
+                id: "last",
+                label: "Last",
+            },
+        ]
+    );
+    assert_eq!(
+        solved.collapsed_tabs(),
+        collapsed
+            .iter()
+            .map(|slot| (slot.id, slot.label))
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]

--- a/crates/gpui-builder/src/solver/child_info.rs
+++ b/crates/gpui-builder/src/solver/child_info.rs
@@ -74,11 +74,14 @@ pub(super) fn allocate_main_axis(
                         && !child.solver_collapsed
                         && nodes[child.node_index].collapsible()
                 })
-                .min_by(|(_, a), (_, b)| {
+                .min_by(|(a_index, a), (b_index, b)| {
                     nodes[a.node_index]
                         .priority()
                         .partial_cmp(&nodes[b.node_index].priority())
                         .unwrap_or(std::cmp::Ordering::Equal)
+                        // Equal priorities preserve declaration order by
+                        // overflowing later siblings first.
+                        .then_with(|| b_index.cmp(a_index))
                 })
                 .map(|(idx, _)| idx)
             else {

--- a/crates/gpui-builder/src/solver/solve.rs
+++ b/crates/gpui-builder/src/solver/solve.rs
@@ -790,6 +790,26 @@ mod tests {
     }
 
     #[test]
+    fn equal_priority_collapses_later_declarations_first() {
+        let children = [
+            collapsible_slot("first", Sizing::Fixed(100.0), 0.5, "First"),
+            collapsible_slot("second", Sizing::Fixed(100.0), 0.5, "Second"),
+            collapsible_slot("third", Sizing::Fixed(100.0), 0.5, "Third"),
+        ];
+        let root = LayoutNode::Container(ContainerNode::new(
+            "root",
+            Axis::Horizontal,
+            Sizing::flex(0.0),
+            &children,
+        ));
+
+        let solved = solve(&root, 200.0, 100.0, &LayoutPreferences::default());
+        assert!(solved.find("first").unwrap().visible);
+        assert!(solved.find("second").unwrap().visible);
+        assert!(!solved.find("third").unwrap().visible);
+    }
+
+    #[test]
     fn all_collapsible_collapse_when_very_tight() {
         let children = [
             collapsible_slot("config", Sizing::fractional(0.2, 100.0), 0.5, "Config"),

--- a/crates/gpui-builder/tests/allocation_contracts.rs
+++ b/crates/gpui-builder/tests/allocation_contracts.rs
@@ -50,6 +50,10 @@ fn warmed_reusable_layout_solves_are_allocation_free() {
             &mut target,
         );
         black_box(target.find("main").unwrap().width());
+        for slot in target.collapsed_slots() {
+            black_box(slot.id);
+            black_box(slot.label);
+        }
     }
 
     AllocationBudget::zero("builder-reusable-layout-resize-1000x")

--- a/crates/gpui-ui-kit/src/adaptive_overflow.rs
+++ b/crates/gpui-ui-kit/src/adaptive_overflow.rs
@@ -1,0 +1,198 @@
+//! Responsive overflow surface for arbitrary interactive content.
+//!
+//! Desktop windows use a [`Popover`], while mobile platforms and narrow
+//! preview windows use a bottom-anchored [`SwipePanel`]. The caller owns the
+//! open state; every dismissal path reports the requested state through the
+//! callback.
+
+use crate::mobile::is_mobile;
+use crate::{Popover, PopoverPlacement, SwipePanel, SwipePanelState};
+use gpui::prelude::{
+    InteractiveElement, IntoElement, ParentElement, RenderOnce, StatefulInteractiveElement, Styled,
+};
+use gpui::{AnyElement, App, ClickEvent, ElementId, KeyDownEvent, Window, div, px};
+use std::rc::Rc;
+
+/// Surface selected by [`AdaptiveOverflow`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdaptiveOverflowPresentation {
+    /// Anchored desktop popover.
+    Popover,
+    /// Mobile bottom sheet.
+    BottomSheet,
+}
+
+type OpenChangeHandler = Rc<dyn Fn(bool, &mut Window, &mut App)>;
+
+/// Controlled responsive overflow for arbitrary trigger and panel content.
+pub struct AdaptiveOverflow {
+    id: ElementId,
+    open: bool,
+    trigger: Option<AnyElement>,
+    content: Option<AnyElement>,
+    on_open_change: Option<OpenChangeHandler>,
+}
+
+impl AdaptiveOverflow {
+    /// Create an overflow surface with a stable element ID.
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            open: false,
+            trigger: None,
+            content: None,
+            on_open_change: None,
+        }
+    }
+
+    /// Set the caller-controlled open state.
+    pub fn open(mut self, open: bool) -> Self {
+        self.open = open;
+        self
+    }
+
+    /// Set arbitrary interactive trigger content.
+    pub fn trigger(mut self, trigger: impl IntoElement) -> Self {
+        self.trigger = Some(trigger.into_any_element());
+        self
+    }
+
+    /// Set arbitrary interactive overflow content.
+    pub fn content(mut self, content: impl IntoElement) -> Self {
+        self.content = Some(content.into_any_element());
+        self
+    }
+
+    /// Report requested controlled-state changes.
+    pub fn on_open_change(
+        mut self,
+        handler: impl Fn(bool, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_open_change = Some(Rc::new(handler));
+        self
+    }
+
+    fn presentation_for_mobile(mobile: bool) -> AdaptiveOverflowPresentation {
+        if mobile {
+            AdaptiveOverflowPresentation::BottomSheet
+        } else {
+            AdaptiveOverflowPresentation::Popover
+        }
+    }
+}
+
+impl RenderOnce for AdaptiveOverflow {
+    fn render(mut self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let mobile = is_mobile(window, cx);
+        let presentation = Self::presentation_for_mobile(mobile);
+        let trigger_focus = cx.focus_handle();
+        let surface_focus = cx.focus_handle();
+        let open = self.open;
+        let on_open_change = self.on_open_change.clone();
+
+        let mut trigger = div()
+            .id((self.id.clone(), "trigger"))
+            .track_focus(&trigger_focus)
+            .focusable()
+            .cursor_pointer();
+        if mobile {
+            trigger = trigger.min_w(px(44.0)).min_h(px(44.0));
+        }
+        if let Some(content) = self.trigger.take() {
+            trigger = trigger.child(content);
+        }
+        if let Some(handler) = on_open_change.clone() {
+            let click_handler = handler.clone();
+            trigger = trigger
+                .on_click(move |_event: &ClickEvent, window, cx| {
+                    click_handler(!open, window, cx);
+                })
+                .on_key_down(move |event: &KeyDownEvent, window, cx| {
+                    if matches!(event.keystroke.key.as_str(), "enter" | "space" | " ") {
+                        handler(!open, window, cx);
+                        cx.stop_propagation();
+                    }
+                });
+        }
+
+        let mut root = div().relative().child(trigger);
+        if !open {
+            return root;
+        }
+
+        let content = self.content.take().map(|content| {
+            div()
+                .id((self.id.clone(), "scroll"))
+                .w_full()
+                .max_h(px(600.0))
+                .overflow_y_scroll()
+                .child(content)
+        });
+
+        match presentation {
+            AdaptiveOverflowPresentation::Popover => {
+                let mut popover = Popover::new(self.id)
+                    .placement(PopoverPlacement::BottomEnd)
+                    .focus_handle(surface_focus)
+                    .restore_focus_to(trigger_focus);
+                if let Some(content) = content {
+                    popover = popover.content(content);
+                }
+                if let Some(handler) = on_open_change {
+                    popover = popover.on_close(move |window, cx| handler(false, window, cx));
+                }
+                root = root.child(popover);
+            }
+            AdaptiveOverflowPresentation::BottomSheet => {
+                let mut panel = SwipePanel::new(self.id)
+                    .state(SwipePanelState::Expanded)
+                    .focus_handle(surface_focus)
+                    .restore_focus_to(trigger_focus);
+                if let Some(content) = content {
+                    panel = panel.content(content);
+                }
+                if let Some(handler) = on_open_change {
+                    panel = panel.on_state_change(move |state, window, cx| {
+                        handler(state != SwipePanelState::Collapsed, window, cx);
+                    });
+                }
+                root = root.child(panel);
+            }
+        }
+        root
+    }
+}
+
+impl IntoElement for AdaptiveOverflow {
+    type Element = gpui::Component<Self>;
+
+    fn into_element(self) -> Self::Element {
+        gpui::Component::new(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AdaptiveOverflow, AdaptiveOverflowPresentation};
+
+    #[test]
+    fn presentation_uses_popover_on_desktop_and_sheet_on_mobile() {
+        assert_eq!(
+            AdaptiveOverflow::presentation_for_mobile(false),
+            AdaptiveOverflowPresentation::Popover
+        );
+        assert_eq!(
+            AdaptiveOverflow::presentation_for_mobile(true),
+            AdaptiveOverflowPresentation::BottomSheet
+        );
+    }
+
+    #[test]
+    fn builder_records_controlled_state_callback() {
+        let overflow = AdaptiveOverflow::new("more")
+            .open(true)
+            .on_open_change(|_, _, _| {});
+        assert!(overflow.open);
+        assert!(overflow.on_open_change.is_some());
+    }
+}

--- a/crates/gpui-ui-kit/src/lib.rs
+++ b/crates/gpui-ui-kit/src/lib.rs
@@ -11,8 +11,9 @@
 
 // Theme, animation, i18n, and accessibility
 pub mod accessibility;
-mod behavior_matrix;
+pub mod adaptive_overflow;
 pub mod animation;
+mod behavior_matrix;
 pub mod color_tokens;
 pub mod design;
 pub mod i18n;
@@ -102,6 +103,7 @@ pub use button::{Button, ButtonSize, ButtonTheme, ButtonVariant};
 pub use button_set::{ButtonSet, ButtonSetOption, ButtonSetSize, ButtonSetTheme};
 pub use icon_button::{IconButton, IconButtonSize, IconButtonTheme, IconButtonVariant};
 // Containers
+pub use adaptive_overflow::{AdaptiveOverflow, AdaptiveOverflowPresentation};
 pub use card::{Card, SlotFactory};
 pub use confirm_dialog::{ConfirmDialog, ConfirmDialogTheme, ConfirmDialogVariant};
 pub use context_menu::{ContextMenu, ContextMenuTheme};
@@ -203,7 +205,7 @@ pub use accessibility::{
     accessibility_readiness_entries, accessibility_readiness_report,
 };
 pub use behavior_matrix::{
-    COMPONENT_BEHAVIOR_REPORT_TYPE, COMPONENT_BEHAVIOR_SCHEMA_VERSION, BehaviorStatus,
+    BehaviorStatus, COMPONENT_BEHAVIOR_REPORT_TYPE, COMPONENT_BEHAVIOR_SCHEMA_VERSION,
     ComponentBehaviorEntry, ComponentBehaviorReport, component_behavior_entries,
     component_behavior_report,
 };

--- a/crates/gpui-ui-kit/src/swipe_panel.rs
+++ b/crates/gpui-ui-kit/src/swipe_panel.rs
@@ -615,7 +615,7 @@ impl Render for SwipePanelEntity {
 }
 
 impl RenderOnce for SwipePanel {
-    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let id = self.id.clone();
         let state = self.state;
         let entity: Entity<SwipePanelEntity> = SWIPE_PANEL_ENTITIES.with(|map| {
@@ -634,6 +634,7 @@ impl RenderOnce for SwipePanel {
 
         entity.update(cx, |model, cx| {
             let mut props = self;
+            let controlled_state = props.state;
             if let Some(content) = props.content.take() {
                 model.content.update(cx, |model, cx| {
                     model.content = Some(content);
@@ -641,6 +642,11 @@ impl RenderOnce for SwipePanel {
                 });
             }
             model.props = props;
+            if model.state != controlled_state {
+                model.state = controlled_state;
+                model.update_target(window);
+                model.ensure_animation(cx);
+            }
         });
         entity.clone().into_any_element()
     }


### PR DESCRIPTION
Closes #29.

## Summary
- add stable allocation-free collapsed slot iteration and deterministic equal-priority collapse ordering to gpui-builder
- add controlled AdaptiveOverflow that selects desktop Popover or mobile SwipePanel
- synchronize controlled SwipePanel state and preserve focus/dismissal behavior

## Verification
- cargo test -p gpui-builder (116 passed)
- cargo test -p gpui-ui-kit (1261 passed, 46 ignored)
- git diff --check