### PR TITLE
Align GPUI documentation policy with vendoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Two open source examples:
 
 ## GPUI Version
 
-This workspace is currently on the `0.9.x` GPUI toolkit line and pins GPUI
-packages to Zed `v1.9.0` through the root [Cargo.toml](./Cargo.toml).
+This workspace is currently on the `0.9.x` GPUI toolkit line and vendors GPUI
+from Zed `v1.9.0`, as recorded in the GPUI snapshot provenance.
 
 The workspace uses local path dependencies for toolkit crates and history-free
 vendored GPUI platform snapshots under `crates/3rdparties/`; the source-origin

--- a/scripts/qa_docs_policy.py
+++ b/scripts/qa_docs_policy.py
@@ -63,10 +63,18 @@ def check() -> list[str]:
     if missing:
         errors.append("README workspace inventory missing: " + ", ".join(missing))
 
-    gpui_tag = re.search(
-        r'^gpui\s*=.*?tag\s*=\s*"([^"]+)"', cargo_text, re.MULTILINE
-    )
-    if not gpui_tag or gpui_tag.group(1) not in readme:
+    gpui_dependency = cargo["workspace"]["dependencies"]["gpui"]
+    gpui_revision = gpui_dependency.get("tag")
+    if gpui_revision is None and (gpui_path := gpui_dependency.get("path")):
+        vendored = ROOT / gpui_path / "VENDORED.md"
+        if vendored.is_file():
+            revision = re.search(
+                r"^- Base ref:\s*(\S+)\s*$", vendored.read_text(), re.MULTILINE
+            )
+            if revision:
+                gpui_revision = revision.group(1)
+
+    if not gpui_revision or gpui_revision not in readme:
         errors.append("README GPUI revision does not match Cargo.toml")
 
     manifest = (ROOT / "crates/gpui-toolkit/src/vendored_patches.rs").read_text()


### PR DESCRIPTION
Refs #33

## Summary
- Resolve the documented GPUI revision from the workspace dependency tag when present.
- For the current path-based vendored dependency, read the revision from crates/3rdparties/gpui/VENDORED.md.
- Clarify README wording so vendored provenance is the documented source of truth.

## Verification
- PYTHONPATH=scripts python3 -m unittest scripts.tests.test_qa_docs_policy (1 passed)
- PYTHONPATH=scripts python3 -m unittest discover -s scripts/tests -p test_*.py (135 passed, 1 skipped)
- git diff --check

## Residual risk
- None identified.