### PR TITLE
Add thinking orb color, dot-size, and speed controls

### DIFF
--- a/crates/gpui-showcase/src/showcase/sections/render_thinking_orb.rs
+++ b/crates/gpui-showcase/src/showcase/sections/render_thinking_orb.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 use gpui::Subscription;
+use gpui::prelude::FluentBuilder as _;
 use gpui_builder::{Axis, ContainerNode, LayoutNode, LayoutPreferences, Sizing, SlotNode, solve};
 use gpui_ui_kit::color::Color;
 use gpui_ui_kit::thinking_orb::{engine, presets};
@@ -14,7 +15,7 @@ const ORB_SIZE: f32 = 96.0;
 const MAX_ORB_SIZE_SCALE: f32 = 8.0;
 const DEFAULT_DOT_SIZE_SCALE: f32 = 1.0;
 const MIN_DOT_SIZE_SCALE: f32 = 0.25;
-const MAX_DOT_SIZE_SCALE: f32 = 4.0;
+const MAX_DOT_SIZE_SCALE: f32 = 20.0;
 const DEFAULT_ORB_SPEED: f32 = 0.5;
 const MIN_ORB_SPEED: f32 = 0.05;
 const MAX_ORB_SPEED: f32 = 2.0;
@@ -190,7 +191,7 @@ impl Render for ThinkingOrbsLab {
             viewport_width - SHOWCASE_SIDEBAR_WIDTH - SHOWCASE_WIDE_CONTENT_PADDING
         };
         let grid_columns = orb_grid_columns(content_width, card_width);
-        let control_columns = orb_grid_columns(content_width, 300.0).min(3);
+        let control_columns = orb_grid_columns(content_width, 400.0).min(2);
         let grid_width =
             card_width * grid_columns as f32 + ORB_GRID_GAP * grid_columns.saturating_sub(1) as f32;
 
@@ -224,6 +225,7 @@ impl Render for ThinkingOrbsLab {
                             .flex()
                             .flex_col()
                             .gap_2()
+                            .when(control_columns == 2, |el| el.col_start(1).col_end(2))
                             .child(
                                 Text::new(format!(
                                     "Points per sphere: {:.0}",
@@ -255,6 +257,7 @@ impl Render for ThinkingOrbsLab {
                             .flex()
                             .flex_col()
                             .gap_2()
+                            .when(control_columns == 2, |el| el.col_start(1).col_end(2))
                             .child(
                                 Text::new(format!(
                                     "Sphere size: {:.2}× ({sphere_size:.0} px)",
@@ -286,6 +289,7 @@ impl Render for ThinkingOrbsLab {
                             .flex()
                             .flex_col()
                             .gap_2()
+                            .when(control_columns == 2, |el| el.col_start(1).col_end(2))
                             .child(
                                 Text::new(format!("Small dot size: {:.2}×", self.dot_size_scale))
                                     .weight(TextWeight::Medium),
@@ -314,6 +318,7 @@ impl Render for ThinkingOrbsLab {
                             .flex()
                             .flex_col()
                             .gap_2()
+                            .when(control_columns == 2, |el| el.col_start(1).col_end(2))
                             .child(
                                 Text::new(format!("Animation speed: {:.2}×", self.speed_scale))
                                     .weight(TextWeight::Medium),
@@ -340,7 +345,10 @@ impl Render for ThinkingOrbsLab {
                     .child(
                         div()
                             .id("thinking-orbs-color-picker")
-                            .w(px(300.0))
+                            .w(px(400.0))
+                            .when(control_columns == 2, |el| {
+                                el.col_start(2).col_end(3).row_start(1).row_end(5)
+                            })
                             .child(self.dot_color_picker.clone()),
                     ),
             )

--- a/crates/gpui-showcase/src/showcase/sections/render_thinking_orb.rs
+++ b/crates/gpui-showcase/src/showcase/sections/render_thinking_orb.rs
@@ -1,7 +1,9 @@
 use super::prelude::*;
+use gpui::Subscription;
 use gpui_builder::{Axis, ContainerNode, LayoutNode, LayoutPreferences, Sizing, SlotNode, solve};
+use gpui_ui_kit::color::Color;
 use gpui_ui_kit::thinking_orb::{engine, presets};
-use gpui_ui_kit::{OrbSize, OrbState, ThinkingOrb};
+use gpui_ui_kit::{ColorPickerView, OrbSize, OrbState, ThinkingOrb};
 use std::time::Duration;
 
 /// Default slider position: points rendered per sphere.
@@ -10,6 +12,12 @@ const DEFAULT_POINTS_PER_SPHERE: f32 = 256.0;
 const ORB_SIZE: f32 = 96.0;
 /// Largest interactive sphere size, expressed as a multiple of [`ORB_SIZE`].
 const MAX_ORB_SIZE_SCALE: f32 = 8.0;
+const DEFAULT_DOT_SIZE_SCALE: f32 = 1.0;
+const MIN_DOT_SIZE_SCALE: f32 = 0.25;
+const MAX_DOT_SIZE_SCALE: f32 = 4.0;
+const DEFAULT_ORB_SPEED: f32 = 0.5;
+const MIN_ORB_SPEED: f32 = 0.05;
+const MAX_ORB_SPEED: f32 = 2.0;
 const ORB_GRID_GAP: f32 = 16.0;
 const SHOWCASE_SIDEBAR_WIDTH: f32 = 220.0;
 const SHOWCASE_WIDE_CONTENT_PADDING: f32 = 64.0;
@@ -33,6 +41,10 @@ pub(crate) struct ThinkingOrbsLab {
     orbs: Vec<(OrbState, Entity<ThinkingOrb>)>,
     points_per_sphere: f32,
     sphere_size_scale: f32,
+    dot_size_scale: f32,
+    speed_scale: f32,
+    dot_color_picker: Entity<ColorPickerView>,
+    _dot_color_subscription: Subscription,
     /// Preset-native dot counts at t=0 (Px64 tuning), per state — the slider
     /// maps its absolute point target to a per-orb `count_scale` factor.
     base_counts: Vec<usize>,
@@ -40,6 +52,7 @@ pub(crate) struct ThinkingOrbsLab {
 
 impl ThinkingOrbsLab {
     pub(crate) fn new(cx: &mut Context<Self>) -> Self {
+        let dot_color = Color::rgb(96, 165, 250);
         let mut orbs = Vec::with_capacity(OrbState::ALL.len());
         let mut base_counts = Vec::with_capacity(OrbState::ALL.len());
         for state in OrbState::ALL {
@@ -49,15 +62,27 @@ impl ThinkingOrbsLab {
                 .len()
                 .max(1);
             base_counts.push(base);
-            let orb = cx.new(|cx| ThinkingOrb::new(state, px(ORB_SIZE), cx));
+            let orb = cx.new(|cx| {
+                ThinkingOrb::new(state, px(ORB_SIZE), cx)
+                    .speed(DEFAULT_ORB_SPEED)
+                    .dot_color(dot_color.to_rgba())
+            });
             let factor = f64::from(DEFAULT_POINTS_PER_SPHERE) / base as f64;
             orb.update(cx, |orb, cx| orb.set_count_scale(factor, cx));
             orbs.push((state, orb));
         }
+        let dot_color_picker = cx.new(|_| ColorPickerView::new("Small dot color", dot_color));
+        let dot_color_subscription = cx.observe(&dot_color_picker, |this, picker, cx| {
+            this.apply_dot_color(picker.read(cx).color(), cx);
+        });
         Self {
             orbs,
             points_per_sphere: DEFAULT_POINTS_PER_SPHERE,
             sphere_size_scale: 1.0,
+            dot_size_scale: DEFAULT_DOT_SIZE_SCALE,
+            speed_scale: DEFAULT_ORB_SPEED,
+            dot_color_picker,
+            _dot_color_subscription: dot_color_subscription,
             base_counts,
         }
     }
@@ -76,6 +101,30 @@ impl ThinkingOrbsLab {
         let size = px(ORB_SIZE * scale);
         for (_state, orb) in &self.orbs {
             orb.update(cx, |orb, cx| orb.set_size(size, cx));
+        }
+        cx.notify();
+    }
+
+    fn apply_dot_size_scale(&mut self, scale: f32, cx: &mut Context<Self>) {
+        self.dot_size_scale = scale;
+        for (_state, orb) in &self.orbs {
+            orb.update(cx, |orb, cx| orb.set_dot_scale(f64::from(scale), cx));
+        }
+        cx.notify();
+    }
+
+    fn apply_speed_scale(&mut self, scale: f32, cx: &mut Context<Self>) {
+        self.speed_scale = scale;
+        for (_state, orb) in &self.orbs {
+            orb.update(cx, |orb, cx| orb.set_speed(scale, cx));
+        }
+        cx.notify();
+    }
+
+    fn apply_dot_color(&mut self, color: Color, cx: &mut Context<Self>) {
+        let rgba = color.to_rgba();
+        for (_state, orb) in &self.orbs {
+            orb.update(cx, |orb, cx| orb.set_dot_color(rgba, cx));
         }
         cx.notify();
     }
@@ -141,6 +190,7 @@ impl Render for ThinkingOrbsLab {
             viewport_width - SHOWCASE_SIDEBAR_WIDTH - SHOWCASE_WIDE_CONTENT_PADDING
         };
         let grid_columns = orb_grid_columns(content_width, card_width);
+        let control_columns = orb_grid_columns(content_width, 300.0).min(3);
         let grid_width =
             card_width * grid_columns as f32 + ORB_GRID_GAP * grid_columns.saturating_sub(1) as f32;
 
@@ -165,61 +215,133 @@ impl Render for ThinkingOrbsLab {
             .child(Heading::h2(cx.t(TranslationKey::SectionThinkingOrbs)))
             .child(
                 div()
-                    .flex()
-                    .flex_col()
-                    .gap_2()
+                    .w_full()
+                    .grid()
+                    .grid_cols(control_columns as u16)
+                    .gap_4()
                     .child(
-                        Text::new(format!("Points per sphere: {:.0}", self.points_per_sphere))
-                            .weight(TextWeight::Medium),
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                Text::new(format!(
+                                    "Points per sphere: {:.0}",
+                                    self.points_per_sphere
+                                ))
+                                .weight(TextWeight::Medium),
+                            )
+                            .child(
+                                div().w(px(300.0)).child(
+                                    Slider::new("orbs-density")
+                                        .min(64.0)
+                                        .max(1024.0)
+                                        .step(1.0)
+                                        .value(self.points_per_sphere)
+                                        .size(SliderSize::Md)
+                                        .on_change({
+                                            let entity = entity.clone();
+                                            move |value, _window, cx| {
+                                                entity.update(cx, |lab, cx| {
+                                                    lab.apply_density(value, cx);
+                                                });
+                                            }
+                                        }),
+                                ),
+                            ),
                     )
                     .child(
-                        div().w(px(300.0)).child(
-                            Slider::new("orbs-density")
-                                .min(64.0)
-                                .max(1024.0)
-                                .step(1.0)
-                                .value(self.points_per_sphere)
-                                .size(SliderSize::Md)
-                                .on_change({
-                                    let entity = entity.clone();
-                                    move |value, _window, cx| {
-                                        entity.update(cx, |lab, cx| {
-                                            lab.apply_density(value, cx);
-                                        });
-                                    }
-                                }),
-                        ),
-                    ),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_2()
-                    .child(
-                        Text::new(format!(
-                            "Sphere size: {:.2}× ({sphere_size:.0} px)",
-                            self.sphere_size_scale,
-                        ))
-                        .weight(TextWeight::Medium),
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                Text::new(format!(
+                                    "Sphere size: {:.2}× ({sphere_size:.0} px)",
+                                    self.sphere_size_scale,
+                                ))
+                                .weight(TextWeight::Medium),
+                            )
+                            .child(
+                                div().w(px(300.0)).child(
+                                    Slider::new("orbs-size")
+                                        .min(1.0)
+                                        .max(MAX_ORB_SIZE_SCALE)
+                                        .step(0.25)
+                                        .value(self.sphere_size_scale)
+                                        .size(SliderSize::Md)
+                                        .on_change({
+                                            let entity = entity.clone();
+                                            move |value, _window, cx| {
+                                                entity.update(cx, |lab, cx| {
+                                                    lab.apply_size_scale(value, cx);
+                                                });
+                                            }
+                                        }),
+                                ),
+                            ),
                     )
                     .child(
-                        div().w(px(300.0)).child(
-                            Slider::new("orbs-size")
-                                .min(1.0)
-                                .max(MAX_ORB_SIZE_SCALE)
-                                .step(0.25)
-                                .value(self.sphere_size_scale)
-                                .size(SliderSize::Md)
-                                .on_change({
-                                    let entity = entity.clone();
-                                    move |value, _window, cx| {
-                                        entity.update(cx, |lab, cx| {
-                                            lab.apply_size_scale(value, cx);
-                                        });
-                                    }
-                                }),
-                        ),
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                Text::new(format!("Small dot size: {:.2}×", self.dot_size_scale))
+                                    .weight(TextWeight::Medium),
+                            )
+                            .child(
+                                div().w(px(300.0)).child(
+                                    Slider::new("orbs-dot-size")
+                                        .min(MIN_DOT_SIZE_SCALE)
+                                        .max(MAX_DOT_SIZE_SCALE)
+                                        .step(0.05)
+                                        .value(self.dot_size_scale)
+                                        .size(SliderSize::Md)
+                                        .on_change({
+                                            let entity = entity.clone();
+                                            move |value, _window, cx| {
+                                                entity.update(cx, |lab, cx| {
+                                                    lab.apply_dot_size_scale(value, cx);
+                                                });
+                                            }
+                                        }),
+                                ),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                Text::new(format!("Animation speed: {:.2}×", self.speed_scale))
+                                    .weight(TextWeight::Medium),
+                            )
+                            .child(
+                                div().w(px(300.0)).child(
+                                    Slider::new("orbs-speed")
+                                        .min(MIN_ORB_SPEED)
+                                        .max(MAX_ORB_SPEED)
+                                        .step(0.05)
+                                        .value(self.speed_scale)
+                                        .size(SliderSize::Md)
+                                        .on_change({
+                                            let entity = entity.clone();
+                                            move |value, _window, cx| {
+                                                entity.update(cx, |lab, cx| {
+                                                    lab.apply_speed_scale(value, cx);
+                                                });
+                                            }
+                                        }),
+                                ),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .id("thinking-orbs-color-picker")
+                            .w(px(300.0))
+                            .child(self.dot_color_picker.clone()),
                     ),
             )
             .child(

--- a/crates/gpui-ui-kit/src/color_picker/mod.rs
+++ b/crates/gpui-ui-kit/src/color_picker/mod.rs
@@ -7,15 +7,16 @@
 
 use crate::color::Color;
 use crate::{
-    Button, ButtonSize, ButtonVariant, HStack, StackSpacing, Text, TextSize, TextWeight, VStack,
+    Button, ButtonSize, ButtonVariant, HStack, NumberInput, NumberInputSize, StackSpacing, Text,
+    TextSize, TextWeight, VStack,
 };
 use gpui::prelude::{
     Context, FluentBuilder as _, InteractiveElement, IntoElement, ParentElement, Render,
     StatefulInteractiveElement, Styled,
 };
 use gpui::{
-    ClickEvent, MouseButton, MouseDownEvent, MouseMoveEvent, Rgba, ScrollWheelEvent, SharedString,
-    Window, div, px,
+    ClickEvent, ElementId, MouseButton, MouseDownEvent, MouseMoveEvent, Rgba, ScrollWheelEvent,
+    SharedString, Window, div, px,
 };
 
 /// Color picker mode
@@ -27,12 +28,31 @@ pub enum ColorPickerMode {
     HSL,
 }
 
+#[derive(Clone, Copy)]
+struct ColorSliderDrag {
+    mode: ColorPickerMode,
+    label: &'static str,
+    start_x: f32,
+    start_value: f32,
+}
+
+fn slider_value_from_drag(
+    start_value: f32,
+    start_x: f32,
+    current_x: f32,
+    bar_width: f32,
+    max: f32,
+) -> f32 {
+    (start_value + (current_x - start_x) / bar_width * max).clamp(0.0, max)
+}
+
 /// Standalone color picker view for use in dialogs
 pub struct ColorPickerView {
     color: Color,
     original_color: Color,
     mode: ColorPickerMode,
     label: SharedString,
+    active_drag: Option<ColorSliderDrag>,
 }
 
 impl ColorPickerView {
@@ -42,6 +62,7 @@ impl ColorPickerView {
             original_color: color,
             mode: ColorPickerMode::RGB,
             label: label.into(),
+            active_drag: None,
         }
     }
 
@@ -108,7 +129,8 @@ impl ColorPickerView {
     }
 
     /// Render a slider with full mouse interaction support:
-    /// - Click and drag to set value
+    /// - Drag left or right to adjust the value
+    /// - Enter an exact value in the adjacent number input
     /// - Scroll wheel to adjust value (shift for fine control)
     /// - Double-click to reset to default
     fn render_slider(
@@ -123,6 +145,9 @@ impl ColorPickerView {
         let mode = self.mode;
         let ratio = value / max;
         let bar_width = 200.0;
+        let channel_id = ElementId::from((ElementId::View(cx.entity_id()), label));
+        let track_id = ElementId::from((channel_id.clone(), "track"));
+        let input_id = ElementId::from((channel_id, "input"));
 
         // Track colors
         let track_bg = Rgba {
@@ -138,8 +163,7 @@ impl ColorPickerView {
             a: 1.0,
         });
 
-        // Helper to calculate new value from x position
-        let calc_value = move |x: f32| -> f32 { (x / bar_width).clamp(0.0, 1.0) * max };
+        let entity = cx.entity().clone();
 
         HStack::new()
             .spacing(StackSpacing::Sm)
@@ -150,7 +174,7 @@ impl ColorPickerView {
             )
             .child(
                 div()
-                    .id(SharedString::from(format!("slider-{}", label)))
+                    .id(track_id)
                     .w(px(bar_width))
                     .h(px(20.0))
                     .bg(track_bg)
@@ -187,21 +211,48 @@ impl ColorPickerView {
                             .border_color(fill_bg)
                             .shadow_sm(),
                     )
-                    // Mouse down - set value on click
+                    // Record absolute pointer position and use movement deltas, so
+                    // the picker works regardless of where it is embedded.
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, event: &MouseDownEvent, _window, cx| {
-                            let new_val = calc_value(event.position.x.into());
-                            Self::apply_slider_value(this, mode, label, new_val, cx);
+                            this.active_drag = Some(ColorSliderDrag {
+                                mode,
+                                label,
+                                start_x: event.position.x.into(),
+                                start_value: value,
+                            });
+                            cx.stop_propagation();
                         }),
                     )
                     // Mouse move while pressed - drag to change value
                     .on_mouse_move(
                         cx.listener(move |this, event: &MouseMoveEvent, _window, cx| {
-                            if event.pressed_button == Some(MouseButton::Left) {
-                                let new_val = calc_value(event.position.x.into());
-                                Self::apply_slider_value(this, mode, label, new_val, cx);
+                            if event.pressed_button != Some(MouseButton::Left) {
+                                return;
                             }
+                            let Some(drag) = this
+                                .active_drag
+                                .filter(|drag| drag.mode == mode && drag.label == label)
+                            else {
+                                return;
+                            };
+                            let new_val = slider_value_from_drag(
+                                drag.start_value,
+                                drag.start_x,
+                                event.position.x.into(),
+                                bar_width,
+                                max,
+                            );
+                            Self::apply_slider_value(this, mode, label, new_val, cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _event, _window, cx| {
+                            this.active_drag = None;
+                            cx.stop_propagation();
                         }),
                     )
                     // Double-click to reset
@@ -236,9 +287,19 @@ impl ColorPickerView {
                     )),
             )
             .child(
-                div().w(px(50.0)).child(
-                    Text::new(SharedString::from(format!("{:.0}", value))).size(TextSize::Sm),
-                ),
+                NumberInput::new(input_id)
+                    .value(f64::from(value))
+                    .min(0.0)
+                    .max(f64::from(max))
+                    .step(1.0)
+                    .decimals(0)
+                    .size(NumberInputSize::Sm)
+                    .width(72.0)
+                    .on_change(move |new_val, _window, cx| {
+                        entity.update(cx, |this, cx| {
+                            Self::apply_slider_value(this, mode, label, new_val as f32, cx);
+                        });
+                    }),
             )
             .build()
     }
@@ -497,5 +558,26 @@ impl Render for ColorPickerView {
                     )
                     .build(),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slider_value_from_drag;
+
+    #[test]
+    fn slider_drag_uses_pointer_delta_and_clamps_to_channel_range() {
+        assert_eq!(
+            slider_value_from_drag(100.0, 500.0, 600.0, 200.0, 255.0),
+            227.5
+        );
+        assert_eq!(
+            slider_value_from_drag(100.0, 500.0, 200.0, 200.0, 255.0),
+            0.0
+        );
+        assert_eq!(
+            slider_value_from_drag(100.0, 500.0, 900.0, 200.0, 255.0),
+            255.0
+        );
     }
 }

--- a/crates/gpui-ui-kit/src/thinking_orb/element.rs
+++ b/crates/gpui-ui-kit/src/thinking_orb/element.rs
@@ -9,7 +9,7 @@ use d3rs::vello2d::peniko::{Brush, Color};
 use d3rs::vello2d::{ChartScene, VelloScenePainter};
 use gpui::{
     App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
-    Pixels, Style, Window, size,
+    Pixels, Rgba, Style, Window, size,
 };
 use std::panic::Location;
 
@@ -22,6 +22,15 @@ fn ink_brush(white: f64, a: Option<f64>, dark: bool) -> Brush {
     Brush::Solid(Color::new([gray, gray, gray, alpha]))
 }
 
+/// Tint preset ink while retaining its light/dark depth fade and alpha.
+fn tint_brush(tint: Rgba, white: f64, a: Option<f64>, dark: bool) -> Brush {
+    let strength = white.clamp(0.0, 1.0) as f32;
+    let background = if dark { 0.0 } else { 1.0 };
+    let mix = |component: f32| background + (component - background) * strength;
+    let alpha = tint.a * a.unwrap_or(1.0).clamp(0.0, 1.0) as f32;
+    Brush::Solid(Color::new([mix(tint.r), mix(tint.g), mix(tint.b), alpha]))
+}
+
 /// Vello-painted element for a single finished [`OrbFrame`], laid out as a
 /// fixed `size` × `size` square. Engine coordinates remain local to that
 /// square: both Vello backends rasterize an element-local scene.
@@ -31,24 +40,40 @@ pub struct ThinkingOrbElement {
     frame: OrbFrame,
     size: Pixels,
     dark: bool,
+    dot_color: Option<Rgba>,
+    dot_scale: f64,
     painter: VelloScenePainter,
 }
 
 impl ThinkingOrbElement {
     #[track_caller]
-    pub fn new(id: ElementId, frame: OrbFrame, size: Pixels, dark: bool) -> Self {
+    pub fn new(
+        id: ElementId,
+        frame: OrbFrame,
+        size: Pixels,
+        dark: bool,
+        dot_color: Option<Rgba>,
+        dot_scale: f64,
+    ) -> Self {
         Self {
             id,
             source_location: Location::caller(),
             frame,
             size,
             dark,
+            dot_color,
+            dot_scale,
             painter: VelloScenePainter::new(),
         }
     }
 }
 
-fn scene_for_frame(frame: &OrbFrame, dark: bool) -> ChartScene {
+fn scene_for_frame(
+    frame: &OrbFrame,
+    dark: bool,
+    dot_color: Option<Rgba>,
+    dot_scale: f64,
+) -> ChartScene {
     let mut scene = ChartScene::new();
     // Lines first, then the z-sorted (far→near) dots.
     for line in &frame.lines {
@@ -59,7 +84,11 @@ fn scene_for_frame(frame: &OrbFrame, dark: bool) -> ChartScene {
         );
     }
     for dot in &frame.dots {
-        scene.fill_circle(dot.x, dot.y, dot.r, ink_brush(dot.white, dot.a, dark));
+        let brush = dot_color.map_or_else(
+            || ink_brush(dot.white, dot.a, dark),
+            |color| tint_brush(color, dot.white, dot.a, dark),
+        );
+        scene.fill_circle(dot.x, dot.y, dot.r * dot_scale, brush);
     }
     scene
 }
@@ -123,7 +152,7 @@ impl Element for ThinkingOrbElement {
         window: &mut Window,
         _cx: &mut App,
     ) {
-        let scene = scene_for_frame(&self.frame, self.dark);
+        let scene = scene_for_frame(&self.frame, self.dark, self.dot_color, self.dot_scale);
         self.painter.paint_retained(id, &scene, bounds, window);
     }
 }
@@ -139,7 +168,7 @@ mod tests {
     fn cpu_scene_has_coverage_at_its_local_raster_origin() {
         let resolved = resolve_preset(OrbState::Working, OrbSize::Px64);
         let frame = engine::frame(resolved.mode, 96.0, 0.0, &resolved.opts);
-        let scene = scene_for_frame(&frame, true);
+        let scene = scene_for_frame(&frame, true, None, 1.0);
 
         let pixels = CpuRasterizer::new(96, 96).rasterize(&scene, 96, 96);
         assert!(

--- a/crates/gpui-ui-kit/src/thinking_orb/mod.rs
+++ b/crates/gpui-ui-kit/src/thinking_orb/mod.rs
@@ -33,7 +33,7 @@ mod component {
     use crate::accessibility::{AccessibilityExt, AccessibilityNode, AriaProps, AriaRole};
     use crate::theme::ThemeExt;
     use gpui::{
-        Context, ElementId, IntoElement, Pixels, Render, SharedString, WeakEntity, Window, px,
+        Context, ElementId, IntoElement, Pixels, Render, Rgba, SharedString, WeakEntity, Window, px,
     };
     use std::time::Duration;
     // `std::time::Instant` panics on wasm32-unknown-unknown ("time not
@@ -45,6 +45,9 @@ mod component {
     /// Lower clamp for [`ThinkingOrb::count_scale`] so radii scaling
     /// (`1 / √factor`) stays finite.
     const MIN_COUNT_SCALE: f64 = 0.01;
+    /// Lower clamp for dot-radius scaling so invalid slider or API input never
+    /// produces zero, negative, or non-finite paint geometry.
+    const MIN_DOT_SCALE: f64 = 0.05;
 
     /// Per-frame geometry statistics for debugging overlays.
     #[derive(Clone, Copy, Debug, Default)]
@@ -81,6 +84,10 @@ mod component {
         speed: f32,
         /// Density multiplier (1.0 = preset-native density).
         count_scale: f64,
+        /// Optional dot tint. Lines retain their preset-native ink.
+        dot_color: Option<Rgba>,
+        /// Dot-radius multiplier (1.0 = preset-native radius).
+        dot_scale: f64,
         paused: bool,
         aria_label: Option<SharedString>,
         /// Preset-native resolution (mode + clock multiplier + base opts).
@@ -109,6 +116,8 @@ mod component {
                 size,
                 speed: 1.0,
                 count_scale: 1.0,
+                dot_color: None,
+                dot_scale: 1.0,
                 paused: false,
                 aria_label: None,
                 resolved,
@@ -124,7 +133,20 @@ mod component {
 
         /// Multiply the preset animation speed (1.0 = preset speed).
         pub fn speed(mut self, speed: f32) -> Self {
-            self.speed = speed;
+            self.speed = valid_speed(speed);
+            self
+        }
+
+        /// Tint dots while preserving their depth and alpha shading. Lines
+        /// retain their preset-native monochrome ink.
+        pub fn dot_color(mut self, color: Rgba) -> Self {
+            self.dot_color = Some(color);
+            self
+        }
+
+        /// Scale every dot radius (1.0 = preset-native radius).
+        pub fn dot_scale(mut self, scale: f64) -> Self {
+            self.dot_scale = valid_dot_scale(scale);
             self
         }
 
@@ -153,6 +175,35 @@ mod component {
         pub fn set_count_scale(&mut self, scale: f64, cx: &mut Context<Self>) {
             self.count_scale = scale.max(MIN_COUNT_SCALE);
             self.opts = scaled_opts(&self.resolved, self.count_scale);
+            cx.notify();
+        }
+
+        /// Update the animation clock multiplier without resetting its phase.
+        pub fn set_speed(&mut self, speed: f32, cx: &mut Context<Self>) {
+            let speed = valid_speed(speed);
+            if self.speed == speed {
+                return;
+            }
+            self.speed = speed;
+            cx.notify();
+        }
+
+        /// Update the live dot tint.
+        pub fn set_dot_color(&mut self, color: Rgba, cx: &mut Context<Self>) {
+            if self.dot_color == Some(color) {
+                return;
+            }
+            self.dot_color = Some(color);
+            cx.notify();
+        }
+
+        /// Update the live dot-radius multiplier.
+        pub fn set_dot_scale(&mut self, scale: f64, cx: &mut Context<Self>) {
+            let scale = valid_dot_scale(scale);
+            if self.dot_scale == scale {
+                return;
+            }
+            self.dot_scale = scale;
             cx.notify();
         }
 
@@ -201,7 +252,7 @@ mod component {
                             return false;
                         }
                         let now = Instant::now();
-                        this.elapsed += now - this.last_tick;
+                        this.elapsed += (now - this.last_tick).mul_f32(this.speed);
                         this.last_tick = now;
                         cx.notify();
                         true
@@ -235,7 +286,7 @@ mod component {
             let size_px: f32 = self.size.into();
             // `Resolved.speed` is the renderer-side clock multiplier — the
             // engine takes a raw t.
-            let t = self.elapsed.as_secs_f64() * f64::from(self.speed) * self.resolved.speed;
+            let t = self.elapsed.as_secs_f64() * self.resolved.speed;
             let start = Instant::now();
             let frame = engine::frame(self.resolved.mode, f64::from(size_px), t, &self.opts);
             self.stats = FrameStats {
@@ -244,7 +295,14 @@ mod component {
                 geometry_time: start.elapsed(),
             };
 
-            ThinkingOrbElement::new(self.id.clone(), frame, self.size, dark)
+            ThinkingOrbElement::new(
+                self.id.clone(),
+                frame,
+                self.size,
+                dark,
+                self.dot_color,
+                self.dot_scale,
+            )
         }
     }
 
@@ -262,5 +320,34 @@ mod component {
     fn scaled_opts(resolved: &Resolved, factor: f64) -> ModeOpts {
         let opts = scale_counts(&resolved.opts, factor);
         scale_radii(&opts, 1.0 / factor.sqrt())
+    }
+
+    fn valid_dot_scale(scale: f64) -> f64 {
+        if scale.is_finite() {
+            scale.max(MIN_DOT_SCALE)
+        } else {
+            1.0
+        }
+    }
+
+    fn valid_speed(speed: f32) -> f32 {
+        if speed.is_finite() {
+            speed.max(0.0)
+        } else {
+            1.0
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{MIN_DOT_SCALE, valid_dot_scale, valid_speed};
+
+        #[test]
+        fn live_control_values_are_bounded_and_finite() {
+            assert_eq!(valid_dot_scale(-1.0), MIN_DOT_SCALE);
+            assert_eq!(valid_dot_scale(f64::INFINITY), 1.0);
+            assert_eq!(valid_speed(-1.0), 0.0);
+            assert_eq!(valid_speed(f32::NAN), 1.0);
+        }
     }
 }


### PR DESCRIPTION
Closes #60.

## Summary
- add live small-dot color, size, and animation-speed controls to the Thinking Orbs showcase
- fix ColorPickerView channel dragging by using pointer deltas instead of absolute window coordinates
- make RGB/HSL/alpha channel values directly editable with bounded number inputs
- align the four demo sliders vertically on the left and place the picker on the right, with a one-column narrow-width fallback
- increase the small-dot size range to 20x and keep the calmer 0.5x animation default
- preserve animation phase during live speed changes and retain preset depth/alpha shading

## Verification
- cargo fmt --all --check
- cargo check -p gpui-ui-kit -p gpui-showcase
- cargo test -p gpui-ui-kit color_picker
- cargo test -p gpui-showcase thinking_orb
- cargo clippy -p gpui-ui-kit -p gpui-showcase --all-targets -- -D warnings -A clippy::chunks_exact_to_as_chunks
- wasm showcase screenshot at 1400x1000 verified the two-column layout and editable channel controls

The in-app browser connection was unavailable for a synthetic pointer gesture; delta dragging is covered by a focused unit test and the component/integration suites.